### PR TITLE
Use werkzeug.exceptions.TooManyRequests if available

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ include =
 omit =
     /*/flask_limiter/_version*
     /*/flask_limiter/backports/*
+    /*/flask_limiter/errors.py
 
 [report]
 exclude_lines =

--- a/flask_limiter/errors.py
+++ b/flask_limiter/errors.py
@@ -2,17 +2,10 @@
 errors and exceptions
 """
 
-import sys
 from distutils.version import LooseVersion
 from pkg_resources import get_distribution
 from werkzeug import exceptions
-
-PY2 = sys.version_info[0] == 2
-
-if PY2:
-    text_type = unicode
-else:
-    text_type = str
+from six import text_type
 
 
 werkzeug_version = get_distribution("werkzeug").version

--- a/flask_limiter/errors.py
+++ b/flask_limiter/errors.py
@@ -2,11 +2,17 @@
 errors and exceptions
 """
 
+import sys
 from distutils.version import LooseVersion
 from pkg_resources import get_distribution
 from werkzeug import exceptions
 
+PY2 = sys.version_info[0] == 2
 
+if PY2:
+    text_type = unicode
+else:
+    text_type = str
 
 
 werkzeug_version = get_distribution("werkzeug").version
@@ -23,7 +29,7 @@ if LooseVersion(werkzeug_version) < LooseVersion("0.9"):  # pragma: no cover
         code = 429
 
         def __init__(self, limit):
-            self.description = str(limit)
+            self.description = text_type(limit)
             super(RateLimitExceeded, self).__init__()
 else:
     # Werkzeug 0.9 and up have an existing exception for 429


### PR DESCRIPTION
Werkzeug already has an exception class for 429 errors for versions after and including 0.9. That exception should be used if possible since currently, this will fail:

```python
try:
    abort(429)
except werkzeug.exceptions.TooManyRequests:
    pass
```

That seems like a stupid example, but consider a situation where a user is implementing a [custom throttling response](http://flask-limiter.readthedocs.org/en/stable/#custom-rate-limit-exceeded-responses), and decides to register the `TooManyRequests` exception instead of `429` (which is more readable IMO).

The custom exception class defined also always casts the description string to ascii on python2, which may have undesired consequences.