### PR TITLE
Pip 7.0.0 removes --use-mirrors flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
     - "pypy"
 
 install:
-    - pip install -r requirements/ci.txt --use-mirrors
-    
+    - pip install -r requirements/ci.txt
+
 services:
     - redis-server
     - memcached


### PR DESCRIPTION
http://pip.readthedocs.org/en/stable/news/