### PR TITLE
Retry-After header always zero when using key prefix

### DIFF
--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -1251,26 +1251,35 @@ class FlaskExtTests(unittest.TestCase):
                 self.assertEqual(resp.data, b'tres')
 
     def test_custom_key_prefix(self):
-        app1, limiter1 = self.build_app(key_prefix="moo", storage_uri="redis://localhost:6379")
-        app2, limiter2 = self.build_app(key_prefix="cow", storage_uri="redis://localhost:6379")
+        app1, limiter1 = self.build_app(key_prefix="moo", storage_uri="redis://localhost:6379", headers_enabled=True)
+        app2, limiter2 = self.build_app(key_prefix="cow", storage_uri="redis://localhost:6379", headers_enabled=True)
+
 
         @app1.route("/test")
-        @limiter1.limit("1/day")
+        @limiter1.limit("1/minute")
         def t1():
             return "app1 test"
 
         @app2.route("/test")
-        @limiter2.limit("1/day")
-        def t1():
-            return "app1 test"
+        @limiter2.limit("1/minute")
+        def t2():
+            return "app2 test"
 
         with app1.test_client() as cli:
             resp = cli.get("/test")
             self.assertEqual(200, resp.status_code)
             resp = cli.get("/test")
+            self.assertEqual(
+                resp.headers.get('Retry-After'),
+                str(60)
+            )
             self.assertEqual(429, resp.status_code)
         with app2.test_client() as cli:
             resp = cli.get("/test")
             self.assertEqual(200, resp.status_code)
             resp = cli.get("/test")
+            self.assertEqual(
+                resp.headers.get('Retry-After'),
+                str(60)
+            )
             self.assertEqual(429, resp.status_code)


### PR DESCRIPTION
The new key_prefix feature appears to cause the Retry-After header to be zero rather than having the value you would expect. Removing key_prefix from the attached test causes it to pass. As soon as you put key_prefix back again it then fails.

I have committed this failing test but am not sure where to start looking with regards to fixing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/flask-limiter/98)
<!-- Reviewable:end -->
