### PR TITLE
Fix malformed configuration table in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -168,10 +168,10 @@ instance are
            caching the response.
         .. note:: The callable is called from within a
            :ref:`flask request context <flask:request-context>`.
-  
+
   Exemption conditions
     Each limit can be exempted when given conditions are fulfilled. These
-    conditions can be specified by supplying a callable as an 
+    conditions can be specified by supplying a callable as an
     ```exempt_when``` argument when defining the limit.
 
         .. code-block:: python
@@ -271,44 +271,44 @@ The following flask configuration values are honored by
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
-===================================== ================================================
-``RATELIMIT_GLOBAL``                  .. deprecated:: 0.9.4. Use ``RATELIMIT_DEFAULT`` instead.
-``RATELIMIT_DEFAULT``                 A comma (or some other delimiter) separated string
-                                      that will be used to apply a default limit on all
-                                      routes. If not provided, the default limits can be
-                                      passed to the :class:`Limiter` constructor
-                                      as well (the values passed to the constructor take precedence
-                                      over those in the config). :ref:`ratelimit-string` for details.
-``RATELIMIT_APPLICATION``             A comma (or some other delimiter) separated string
-                                      that will be used to apply limits to the application as a whole (i.e. shared
-                                      by all routes).
-``RATELIMIT_STORAGE_URL``             One of ``memory://`` or ``redis://host:port``
-                                      or ``memcached://host:port``. Using the redis storage
-                                      requires the installation of the `redis`_ package
-                                      while memcached relies on the `pymemcache`_ package.
-                                      (For details refer to :ref:`storage-scheme`)
-``RATELIMIT_STORAGE_OPTIONS``         A dictionary to set extra options to be passed to the
-                                      storage implementation upon initialization. (Useful if you're
-                                      subclassing :class:`limits.storage.Storage` to create a
-                                      custom Storage backend.)
-``RATELIMIT_STRATEGY``                The rate limiting strategy to use.  :ref:`ratelimit-strategy`
-                                      for details.
-``RATELIMIT_HEADERS_ENABLED``         Enables returning :ref:`ratelimit-headers`. Defaults to ``False``
-``RATELIMIT_ENABLED``                 Overall kill switch for rate limits. Defaults to ``True``
-``RATELIMIT_HEADER_LIMIT``            Header for the current rate limit. Defaults to ``X-RateLimit-Limit``
-``RATELIMIT_HEADER_RESET``            Header for the reset time of the current rate limit. Defaults to ``X-RateLimit-Reset``
-``RATELIMIT_HEADER_REMAINING``        Header for the number of requests remaining in the current rate limit. Defaults to ``X-RateLimit-Remaining``
+======================================= ================================================
+``RATELIMIT_GLOBAL``                    .. deprecated:: 0.9.4. Use ``RATELIMIT_DEFAULT`` instead.
+``RATELIMIT_DEFAULT``                   A comma (or some other delimiter) separated string
+                                        that will be used to apply a default limit on all
+                                        routes. If not provided, the default limits can be
+                                        passed to the :class:`Limiter` constructor
+                                        as well (the values passed to the constructor take precedence
+                                        over those in the config). :ref:`ratelimit-string` for details.
+``RATELIMIT_APPLICATION``               A comma (or some other delimiter) separated string
+                                        that will be used to apply limits to the application as a whole (i.e. shared
+                                        by all routes).
+``RATELIMIT_STORAGE_URL``               One of ``memory://`` or ``redis://host:port``
+                                        or ``memcached://host:port``. Using the redis storage
+                                        requires the installation of the `redis`_ package
+                                        while memcached relies on the `pymemcache`_ package.
+                                        (For details refer to :ref:`storage-scheme`)
+``RATELIMIT_STORAGE_OPTIONS``           A dictionary to set extra options to be passed to the
+                                        storage implementation upon initialization. (Useful if you're
+                                        subclassing :class:`limits.storage.Storage` to create a
+                                        custom Storage backend.)
+``RATELIMIT_STRATEGY``                  The rate limiting strategy to use.  :ref:`ratelimit-strategy`
+                                        for details.
+``RATELIMIT_HEADERS_ENABLED``           Enables returning :ref:`ratelimit-headers`. Defaults to ``False``
+``RATELIMIT_ENABLED``                   Overall kill switch for rate limits. Defaults to ``True``
+``RATELIMIT_HEADER_LIMIT``              Header for the current rate limit. Defaults to ``X-RateLimit-Limit``
+``RATELIMIT_HEADER_RESET``              Header for the reset time of the current rate limit. Defaults to ``X-RateLimit-Reset``
+``RATELIMIT_HEADER_REMAINING``          Header for the number of requests remaining in the current rate limit. Defaults to ``X-RateLimit-Remaining``
 ``RATELIMIT_HEADER_RETRY_AFTER``        Header for when the client should retry the request. Defaults to ``Retry-After``
 ``RATELIMIT_HEADER_RETRY_AFTER_VALUE``  Allows configuration of how the value of the `Retry-After` header is rendered. One of `http-date` or `delta-seconds`. (`RFC2616`_).
-``RATELIMIT_SWALLOW_ERRORS``          Whether to allow failures while attempting to perform a rate limit
-                                      such as errors with downstream storage. Setting this value to ``True``
-                                      will effectively disable rate limiting for requests where an error has
-                                      occurred.
-``RATELIMIT_IN_MEMORY_FALLBACK``      A comma (or some other delimiter) separated string
-                                      that will be used when the configured storage is down.
-``RATELIMIT_KEY_PREFIX``              Prefix that is prepended to each stored rate limit key. This can be useful when using a
-                                      shared storage for multiple applications or rate limit domains.
-===================================== ================================================
+``RATELIMIT_SWALLOW_ERRORS``            Whether to allow failures while attempting to perform a rate limit
+                                        such as errors with downstream storage. Setting this value to ``True``
+                                        will effectively disable rate limiting for requests where an error has
+                                        occurred.
+``RATELIMIT_IN_MEMORY_FALLBACK``        A comma (or some other delimiter) separated string
+                                        that will be used when the configured storage is down.
+``RATELIMIT_KEY_PREFIX``                Prefix that is prepended to each stored rate limit key. This can be useful when using a
+                                        shared storage for multiple applications or rate limit domains.
+======================================= ================================================
 
 .. _ratelimit-string:
 


### PR DESCRIPTION
A prior change to correct some configuration names cause the configuration table to be malformed, thus not appearing in the output of the documentation. Sphinx raises the following during the docs build:

    WARNING: Malformed table.
    Text in column margin in table line 29.

This change adds some spacing to properly align the table columns so there's no overflow around long names like `RATELIMIT_HEADER_RETRY_AFTER_VALUE`. With this change, https://flask-limiter.readthedocs.io/en/latest/#configuration would be properly rendered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/flask-limiter/135)
<!-- Reviewable:end -->
