### PR TITLE
Handle storage errors in __inject_headers so Flask.after_request doesn't fail

### DIFF
--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -301,13 +301,13 @@ class Limiter(object):
     def __inject_headers(self, response):
         current_limit = getattr(g, 'view_rate_limit', None)
         if self.enabled and self._headers_enabled and current_limit:
-            response.headers.add(
-                self._header_mapping[HEADERS.LIMIT],
-                str(current_limit[0].amount)
-            )
             try:
                 window_stats = self.limiter.get_window_stats(*current_limit)
                 reset_in = 1 + window_stats[0]
+                response.headers.add(
+                    self._header_mapping[HEADERS.LIMIT],
+                    str(current_limit[0].amount)
+                )
                 response.headers.add(
                     self._header_mapping[HEADERS.REMAINING], window_stats[1]
                 )
@@ -342,6 +342,7 @@ class Limiter(object):
                         " in-memory storage"
                     )
                     self._storage_dead = True
+                    self.__inject_headers(response)
                 if self._swallow_errors:
                     self.logger.exception(
                         "Failed to update rate limit headers. Swallowing error"

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -342,7 +342,7 @@ class Limiter(object):
                         " in-memory storage"
                     )
                     self._storage_dead = True
-                    self.__inject_headers(response)
+                    response = self.__inject_headers(response)
                 if self._swallow_errors:
                     self.logger.exception(
                         "Failed to update rate limit headers. Swallowing error"


### PR DESCRIPTION
Currently if the storage (Redis, etc.) fails after the request processing begins but before the response is completed, Limiter.__inject_headers allows the exception to propagate and the response is not sent. Following the pattern in __check_request_limit, this PR handles such an exception gracefully, allowing swallow_errors to be honored and a response without limit-related headers to be returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/flask-limiter/183)
<!-- Reviewable:end -->
