### PR TITLE
Provide Limit Information with the Exception

### DIFF
--- a/flask_limiter/errors.py
+++ b/flask_limiter/errors.py
@@ -4,25 +4,35 @@ errors and exceptions
 
 from distutils.version import LooseVersion
 from pkg_resources import get_distribution
-from werkzeug import exceptions
 from six import text_type
+from werkzeug import exceptions
 
+werkzeug_exception = None
 werkzeug_version = get_distribution("werkzeug").version
 if LooseVersion(werkzeug_version) < LooseVersion("0.9"):  # pragma: no cover
     # sorry, for touching your internals :).
     import werkzeug._internal
     werkzeug._internal.HTTP_STATUS_CODES[429] = 'Too Many Requests'
-
-    class RateLimitExceeded(exceptions.HTTPException):
-        """
-        exception raised when a rate limit is hit.
-        The exception results in ``abort(429)`` being called.
-        """
-        code = 429
-
-        def __init__(self, limit):
-            self.description = text_type(limit)
-            super(RateLimitExceeded, self).__init__()
+    werkzeug_exception = exceptions.HTTPException
 else:
     # Werkzeug 0.9 and up have an existing exception for 429
-    RateLimitExceeded = exceptions.TooManyRequests
+    werkzeug_exception = exceptions.TooManyRequests
+
+
+class RateLimitExceeded(werkzeug_exception):
+    """
+    exception raised when a rate limit is hit.
+    The exception results in ``abort(429)`` being called.
+    """
+    code = 429
+    limit = None
+
+    def __init__(self, limit):
+        self.limit = limit
+        if limit.error_message:
+            description = limit.error_message if not callable(
+                limit.error_message
+            ) else limit.error_message()
+        else:
+            description = text_type(limit.limit)
+        super(RateLimitExceeded, self).__init__(description=description)

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -373,13 +373,7 @@ class Limiter(object):
         g.view_rate_limit = limit_for_header
 
         if failed_limit:
-            if failed_limit.error_message:
-                exc_description = failed_limit.error_message if not callable(
-                    failed_limit.error_message
-                ) else failed_limit.error_message()
-            else:
-                exc_description = six.text_type(failed_limit.limit)
-            raise RateLimitExceeded(exc_description)
+            raise RateLimitExceeded(failed_limit)
 
     def __check_request_limit(self, in_middleware=True):
         endpoint = request.endpoint or ""


### PR DESCRIPTION
When a RateLimitExceeded exception occurs, we have a need to know which limit failed. I believe this PR does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/flask-limiter/202)
<!-- Reviewable:end -->
