### PR TITLE
Support conditionally deducting from available limits

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -520,6 +520,31 @@ json response instead::
                 , 429
         )
 
+Customizing rate limits based on response
+-----------------------------------------
+For scenarios where the decision to count the current request towards a rate limit
+can only be made after the request has completed, a callable that accepts the current
+:class:`flask.Response` object as its argument can be provided to the :meth:`Limiter.limit` or
+:meth:`Limiter.shared_limit` decorators through the ``deduct_when`` keyword arugment.
+A truthy response from the callable will result in a deduction from the rate limit.
+
+As an example, to only count non `200` responses towards the rate limit
+
+
+.. code-block:: python
+
+        @app.route("..")
+        @limiter.limit(
+            "1/second",
+            deduct_when=lambda response: response.status_code != 200
+        )
+        def route():
+           ...
+
+
+.. note:: All requests will be tested for the rate limit and rejected accordingly
+ if the rate limit is already hit. The providion of the `deduct_when`
+ argument only changes whether the request will count towards depleting the rate limit.
 
 
 Using Flask Pluggable Views

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -182,7 +182,8 @@ instance are
            on the decorated route. For expensive retrievals, consider
            caching the response.
         .. note:: The callable is called from within a
-           :ref:`flask request context <flask:request-context>`.
+           :ref:`flask request context <flask:request-context>` during the
+           `before_request` phase.
 
   Exemption conditions
     Each limit can be exempted when given conditions are fulfilled. These
@@ -296,6 +297,12 @@ the :class:`Limiter` constructor, those will take precedence.
                                           over those in the config). :ref:`ratelimit-string` for details.
 ``RATELIMIT_DEFAULTS_PER_METHOD``         Whether default limits are applied per method, per route or as a
                                           combination of all method per route.
+``RATELIMIT_DEFAULTS_EXEMPT_WHEN``        A function that should return a truthy value if the default rate limit(s)
+                                          should be skipped for the current request. This callback is called in the
+                                          :ref:`flask request context <flask:request-context>` `before_request` phase.
+``RATELIMIT_DEFAULTS_DEDUCT_WHEN``        A function that should return a truthy value if a deduction should be made
+                                          from the default rate limit(s) for the current request. This callback is called
+                                          in the :ref:`flask request context <flask:request-context>` `after_request` phase.
 ``RATELIMIT_APPLICATION``                 A comma (or some other delimiter) separated string
                                           that will be used to apply limits to the application as a whole (i.e. shared
                                           by all routes).

--- a/flask_limiter/wrappers.py
+++ b/flask_limiter/wrappers.py
@@ -9,7 +9,7 @@ class Limit(object):
 
     def __init__(
         self, limit, key_func, scope, per_method, methods, error_message,
-        exempt_when, override_defaults
+        exempt_when, override_defaults, deduct_when
     ):
         self.limit = limit
         self.key_func = key_func
@@ -19,6 +19,7 @@ class Limit(object):
         self.error_message = error_message
         self.exempt_when = exempt_when
         self.override_defaults = override_defaults
+        self.deduct_when = deduct_when
 
     @property
     def is_exempt(self):
@@ -44,7 +45,7 @@ class LimitGroup(object):
 
     def __init__(
         self, limit_provider, key_function, scope, per_method, methods,
-        error_message, exempt_when, override_defaults
+        error_message, exempt_when, override_defaults, deduct_when
     ):
         self.__limit_provider = limit_provider
         self.__scope = scope
@@ -54,6 +55,7 @@ class LimitGroup(object):
         self.error_message = error_message
         self.exempt_when = exempt_when
         self.override_defaults = override_defaults
+        self.deduct_when = deduct_when
 
     def __iter__(self):
         limit_items = parse_many(
@@ -63,5 +65,6 @@ class LimitGroup(object):
         for limit in limit_items:
             yield Limit(
                 limit, self.key_function, self.__scope, self.per_method,
-                self.methods, self.error_message, self.exempt_when, self.override_defaults
+                self.methods, self.error_message, self.exempt_when, self.override_defaults,
+                self.deduct_when
             )

--- a/tests/test_flask_ext.py
+++ b/tests/test_flask_ext.py
@@ -18,6 +18,7 @@ from flask.views import View, MethodView
 from limits.errors import ConfigurationError
 from limits.storage import MemcachedStorage
 from limits.strategies import MovingWindowRateLimiter
+from werkzeug.exceptions import BadRequest, InternalServerError
 
 from flask_limiter.extension import C, Limiter, HEADERS
 from flask_limiter.util import get_remote_address, get_ipaddr
@@ -391,6 +392,71 @@ class DecoratorTests(FlaskLimiterTestCase):
             self.assertEqual(cli.get("/t1").status_code, 429)
             self.assertEqual(cli.get("/t2").status_code, 200)
             self.assertEqual(cli.get("/t2").status_code, 200)
+
+    def test_decorated_limit_with_conditional_deduction(self):
+        app, limiter = self.build_app()
+
+        @app.route("/t/<path:path>")
+        @limiter.limit("1/second", deduct_when=lambda resp: resp.status_code == 200)
+        @limiter.limit("1/minute", deduct_when=lambda resp: resp.status_code == 400)
+        def t(path):
+            if path == "1":
+                return "test"
+            raise BadRequest()
+
+        with hiro.Timeline() as timeline:
+            with app.test_client() as cli:
+                self.assertEqual(cli.get("/t/1").status_code, 200)
+                self.assertEqual(cli.get("/t/1").status_code, 429)
+                timeline.forward(1)
+                self.assertEqual(cli.get("/t/2").status_code, 400)
+                timeline.forward(1)
+                self.assertEqual(cli.get("/t/1").status_code, 429)
+                self.assertEqual(cli.get("/t/2").status_code, 429)
+                timeline.forward(60)
+                self.assertEqual(cli.get("/t/1").status_code, 200)
+
+    def test_shared_limit_with_conditional_deduction(self):
+        app, limiter = self.build_app()
+
+        bp = Blueprint("main", __name__)
+
+        limit = limiter.shared_limit(
+            "2/minute", "not_found",
+            deduct_when=lambda response: response.status_code == 400
+        )
+
+        @app.route("/test/<path:path>")
+        @limit
+        def app_test(path):
+            if path != "1":
+                raise BadRequest()
+            return path
+
+        @bp.route("/test/<path:path>")
+        def bp_test(path):
+            if path != "1":
+                raise BadRequest()
+            return path
+
+        limit(bp)
+
+        app.register_blueprint(bp, url_prefix='/bp')
+
+        with hiro.Timeline() as timeline:
+            with app.test_client() as cli:
+                self.assertEqual(cli.get("/bp/test/1").status_code, 200)
+                self.assertEqual(cli.get("/bp/test/1").status_code, 200)
+                self.assertEqual(cli.get("/test/1").status_code, 200)
+                self.assertEqual(cli.get("/bp/test/2").status_code, 400)
+                self.assertEqual(cli.get("/test/2").status_code, 400)
+                self.assertEqual(cli.get("/bp/test/2").status_code, 429)
+                self.assertEqual(cli.get("/bp/test/1").status_code, 429)
+                self.assertEqual(cli.get("/test/1").status_code, 429)
+                self.assertEqual(cli.get("/test/2").status_code, 429)
+                timeline.forward(60)
+                self.assertEqual(cli.get("/bp/test/1").status_code, 200)
+                self.assertEqual(cli.get("/test/1").status_code, 200)
 
     def test_decorated_limits_with_combined_defaults(self):
         app, limiter = self.build_app(


### PR DESCRIPTION
Addresses #234

### Example
#### Only count non 200 responses towards the limit

In the example below every time the route is accessed in error a deduction will occur and when the limit is hit subsequent requests within the second will be blocked.

```python
def deduct_on_error(response):
    if response.status_code != 200:
         return True
    return False

@app.route("....")
@limiter.limit("10/second", deduct_when=deduct_on_error)
def route():
   ....

```

#### Use separate limits for errors
In this example both successful and unsuccessful requests will count towards the corresponding rate limits. If the requests all succeed there can be up to 100 requests per second, however the first unsuccessful request will result in all subsequent requests within the second being blocked.
```python

@app.route("...")
@limit.limit("1/second", deduct_when=lambda r: r.status_code != 200)
@limit.limit("100/second", deduct_when=lambda r: r.status_code == 200)
def route():
    ...
```
