### PR TITLE
Optimize limit exemption by key func

### DIFF
--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -451,40 +451,41 @@ class Limiter(object):
 
         for lim in limits:
             limit_scope = lim.scope or endpoint
-            if lim.is_exempt or lim.method_exempt:
-                continue
             if lim.per_method:
                 limit_scope += ":%s" % request.method
             limit_key = lim.key_func()
-
             args = [limit_key, limit_scope]
-            if all(args):
-                if self._key_prefix:
-                    args = [self._key_prefix] + args
-
-                if lim.deduct_when:
-                    g.conditional_deductions[lim] = args
-                    method = self.limiter.test
-                else:
-                    if not limit_for_header or lim.limit < limit_for_header[0]:
-                        limit_for_header = [lim.limit] + args
-
-                    method = self.limiter.hit
-
-                if not method(lim.limit, *args):
-                    self.logger.warning(
-                        "ratelimit %s (%s) exceeded at endpoint: %s",
-                        lim.limit, limit_key, limit_scope
-                    )
-                    failed_limit = lim
-                    limit_for_header = [lim.limit] + args
-                    break
-            else:
+            if not all(args):
                 self.logger.error(
                     "Skipping limit: %s. Empty value found in parameters.",
                     lim.limit
                 )
                 continue
+
+            if lim.is_exempt or lim.method_exempt:
+                continue
+
+            if self._key_prefix:
+                args = [self._key_prefix] + args
+
+            if lim.deduct_when:
+                g.conditional_deductions[lim] = args
+                method = self.limiter.test
+            else:
+                if not limit_for_header or lim.limit < limit_for_header[0]:
+                    limit_for_header = [lim.limit] + args
+
+                method = self.limiter.hit
+
+            if not method(lim.limit, *args):
+                self.logger.warning(
+                    "ratelimit %s (%s) exceeded at endpoint: %s",
+                    lim.limit, limit_key, limit_scope
+                )
+                failed_limit = lim
+                limit_for_header = [lim.limit] + args
+                break
+
         g.view_rate_limit = limit_for_header
 
         if failed_limit:


### PR DESCRIPTION
This PR changes a little the order of `args` checks in order to get the key function before the exemption status.

This helps people design their rate-limiting at request time while they want exemption based on some DB transactions, like so:

1. Let's say we decide the exemption at request time if we were able to find in the DB what the user was looking for, otherwise we don't want to count that request against the limit. (so clients get counted for valuable received data only)
2. But since the exemption polls the DB, this takes time and this replicates for any string limits you want to skip, which can be a LOT.
3. Why having a LOT of limits that can be skipped? Because for each client you may want to have a different limit, so you decorate the function with all of them and once a client hits the function, you check the limits based on the request data and just for one of them you return a not `None` key_func return value.
4. This change checks the key values first, skips all of them beside one (the one targeting the client) and then you proceed further with exemption check and so on.

----

Question: Is it possible to find some other (simpler) way of applying a custom limit depending on the requesting client?
Real-life scenario: we have trial clients, premium clients, corporate ones and all of them are paying differently for the service, thus having a custom limit for each requester. They are identified through a token at request time and only then we can figure out what limit applies, therefore we want to apply that specific limit only, but since we're using a Flask Resource GET API method, we should decorate this in advance through `decorators`. (the problem is we can decorate correctly at request time only, therefore that's why the workaround above of decorating from the start with all the limits we've got and at request time decide what's the specific one based on the provided token by the client)

Any kind of input will be much appreciated!