### PR TITLE
Expanded logging docs to cover logging level

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -632,17 +632,21 @@ Logging
 -------
 Each :class:`Limiter` instance has a ``logger`` instance variable that is by
 default **not** configured with a handler. You can add your own handler to obtain
-log messages emitted by :mod:`flask_limiter`.
+log messages emitted by :mod:`flask_limiter`. **Note** you will also need to set the
+log level for this handler, as by default it uses the ``NOTSET`` level. This logger is an instance of the 
+[Python Logger](https://docs.python.org/3/library/logging.html).
 
 Simple stdout handler::
 
     limiter = Limiter(app, key_func=get_remote_address)
+    limiter.logger.setLevel("WARNING")
     limiter.logger.addHandler(StreamHandler())
 
 Reusing all the handlers of the ``logger`` instance of the :class:`flask.Flask` app::
 
     app = Flask(__name__)
     limiter = Limiter(app, key_func=get_remote_address)
+    limiter.logger.setLevel("WARNING")
     for handler in app.logger.handlers:
         limiter.logger.addHandler(handler)
 


### PR DESCRIPTION
The default limiter logger does not have a log level set. I've expanded the docs with a note and an example of how to set this to avoid confusion (as happened to me!)

I'm happy to make further changes if you think it's worthwhile adding a Flask-Limiter logging level to the config, but I think this doc change is sufficient, and puts the onus onto the library user, rather than filling up Flask-Limiter with only slightly related logic.