### PR TITLE
Added a "get_remote_address_cloudflare()" function to flask_limiter.util

### DIFF
--- a/flask_limiter/contrib/__init__.py
+++ b/flask_limiter/contrib/__init__.py
@@ -1,0 +1,2 @@
+"""Contributed 'recipes'"""
+from .util import *

--- a/flask_limiter/contrib/util.py
+++ b/flask_limiter/contrib/util.py
@@ -1,0 +1,9 @@
+from flask import request
+
+def get_remote_address_cloudflare() -> str:
+    """
+    :return: the ip address for the current request from the CF-Connecting-IP header
+     (or 127.0.0.1 if none found)
+
+    """
+    return request.headers['CF-Connecting-IP'] or '127.0.0.1'

--- a/flask_limiter/util.py
+++ b/flask_limiter/util.py
@@ -8,11 +8,3 @@ def get_remote_address() -> str:
 
     """
     return request.remote_addr or "127.0.0.1"
-
-def get_remote_address_cloudflare() -> str:
-    """
-    :return: the ip address for the current request from the CF-Connecting-IP header
-     (or 127.0.0.1 if none found)
-
-    """
-    return request.headers['CF-Connecting-IP'] or '127.0.0.1'

--- a/flask_limiter/util.py
+++ b/flask_limiter/util.py
@@ -9,7 +9,7 @@ def get_remote_address() -> str:
     """
     return request.remote_addr or "127.0.0.1"
 
-def get_remote_address_cloudflare():
+def get_remote_address_cloudflare()  -> str:
     """
     :return: the ip address for the current request from the CF-Connecting-IP header
      (or 127.0.0.1 if none found)

--- a/flask_limiter/util.py
+++ b/flask_limiter/util.py
@@ -8,3 +8,11 @@ def get_remote_address() -> str:
 
     """
     return request.remote_addr or "127.0.0.1"
+
+def get_remote_address_cloudflare():
+    """
+    :return: the ip address for the current request from the CF-Connecting-IP header
+     (or 127.0.0.1 if none found)
+
+    """
+    return request.headers['CF-Connecting-IP'] or '127.0.0.1'

--- a/flask_limiter/util.py
+++ b/flask_limiter/util.py
@@ -9,7 +9,7 @@ def get_remote_address() -> str:
     """
     return request.remote_addr or "127.0.0.1"
 
-def get_remote_address_cloudflare()  -> str:
+def get_remote_address_cloudflare() -> str:
     """
     :return: the ip address for the current request from the CF-Connecting-IP header
      (or 127.0.0.1 if none found)


### PR DESCRIPTION
I've been using flask_limiter for the past few months and recently wanted to add cloudflare to provide DDOS protection to my website. I realised that the IP address recieved from cloudflare is from one of cloudflares servers which could cause problems with the rate limiting. For example, if multiple people have their traffic being sent through the same server they would all end up getting rate limited instead of being individually rate limited. 
To solve this issue I added the "get_remote_address_cloudflare()" function so it would get the users ip from the CF-Connecting-IP header instead (which provides the client IP address).
It can be used as a direct replacement for the "get_remote_address()" function.