### PR TITLE
Support for nested blueprints

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -7,13 +7,11 @@ Extension
 ---------
 .. autoclass:: Limiter
 
-Helpers
--------
+Utilities
+---------
+.. autoclass:: ExemptionScope
 .. autoclass:: RequestLimit
 .. autoclass:: HEADERS
-
--------
-
 .. automodule:: flask_limiter.util
 
 Exceptions

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -18,5 +18,7 @@ Helpers
 
 Exceptions
 ----------
+.. currentmodule:: flask_limiter
+
 .. autoexception:: RateLimitExceeded
    :no-inherited-members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinxcontrib.programoutput",
+    "sphinx_issues",
     "sphinx_panels",
     "sphinx_paramlinks",
 ]
@@ -75,6 +76,7 @@ autoclass_content = "both"
 autodoc_typehints_format = "short"
 autosectionlabel_maxdepth = 3
 autosectionlabel_prefix_document = True
+issues_github_path = "alisaifee/flask-limiter"
 
 ogp_image = "_static/logo.png"
 

--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -1,5 +1,6 @@
 Recipes
 =======
+.. currentmodule:: flask_limiter
 
 .. _keyfunc-customization:
 
@@ -7,8 +8,8 @@ Rate Limit Key Functions
 -------------------------
 
 You can easily customize your rate limits to be based on any
-characteristic of the incoming request. Both the :class:`~flask_limiter.Limiter` constructor
-and the :meth:`~flask_limiter.Limiter.limit` decorator accept a keyword argument
+characteristic of the incoming request. Both the :class:`~Limiter` constructor
+and the :meth:`~Limiter.limit` decorator accept a keyword argument
 ``key_func`` that should return a string (or an object that has a string representation).
 
 Rate limiting a route by current user (using Flask-Login)::
@@ -38,9 +39,10 @@ Rate limiting all requests by country::
 
 Custom Rate limit exceeded responses
 ------------------------------------
-The default configuration results in an ``abort(429)`` being called every time
-a rate limit is exceeded for a particular route. The exceeded limit is added to
-the response and results in an response body that looks something like:
+The default configuration results in a :exc:`RateLimitExceeded` exception being
+thrown (**which effectively halts any further processing and a response with status `429`**).
+
+The exceeded limit is added to the response and results in an response body that looks something like:
 
 .. code:: html
 
@@ -65,8 +67,8 @@ Customizing rate limits based on response
 -----------------------------------------
 For scenarios where the decision to count the current request towards a rate limit
 can only be made after the request has completed, a callable that accepts the current
-:class:`flask.Response` object as its argument can be provided to the :meth:`~flask_limiter.Limiter.limit` or
-:meth:`~flask_limiter.Limiter.shared_limit` decorators through the ``deduct_when`` keyword arugment.
+:class:`flask.Response` object as its argument can be provided to the :meth:`~Limiter.limit` or
+:meth:`~Limiter.shared_limit` decorators through the ``deduct_when`` keyword arugment.
 A truthy response from the callable will result in a deduction from the rate limit.
 
 As an example, to only count non `200` responses towards the rate limit
@@ -113,7 +115,7 @@ work. You can add rate limits to your view classes using the following approach.
 .. note:: This approach is limited to either sharing the same rate limit for
  all http methods of a given :class:`flask.views.View` or applying the declared
  rate limit independently for each http method (to accomplish this, pass in ``True`` to
- the ``per_method`` keyword argument to :meth:`~flask_limiter.Limiter.limit`). Alternatively, the limit
+ the ``per_method`` keyword argument to :meth:`~Limiter.limit`). Alternatively, the limit
  can be restricted to only certain http methods by passing them as a list to the `methods`
  keyword argument.
 
@@ -121,10 +123,18 @@ work. You can add rate limits to your view classes using the following approach.
 The above approach has been tested with sub-classes of  :class:`flask.views.View`,
 :class:`flask.views.MethodView` and :class:`flask_restful.Resource`.
 
-Rate limiting all routes in a :class:`flask.Blueprint`
+Rate limiting all routes in a :class:`~flask.Blueprint`
 ------------------------------------------------------
-:meth:`~flask_limiter.Limiter.limit`, :meth:`~flask_limiter.Limiter.shared_limit` &
-:meth:`~flask_limiter.Limiter.exempt` can all be tpplied to :class:`flask.Blueprint` instances as well.
+
+.. warning:: :class:`~flask.Blueprint` instances that are registered on another blueprint
+   instead of on the main :class:`~flask.Flask` instance had not been considered
+   upto :ref:`changelog:v2.3.0`. Effectively **they neither inherited** the rate limits
+   explicitely registered on the parent :class:`~flask.Blueprint` **nor were they
+   exempt** from rate limits if the parent had been marked exempt.
+   (See :issue:`326`, and the :ref:`recipes:nested blueprints` section below).
+
+:meth:`~Limiter.limit`, :meth:`~Limiter.shared_limit` &
+:meth:`~Limiter.exempt` can all be tpplied to :class:`flask.Blueprint` instances as well.
 In the following example the **login** Blueprint has a special rate limit applied to all its routes, while
 the **help** Blueprint is exempt from all rate limits. The **regular** Blueprint follows the default rate limits.
 
@@ -159,12 +169,84 @@ the **help** Blueprint is exempt from all rate limits. The **regular** Blueprint
    app.register_blueprint(regular)
 
 
+Nested Blueprints
+^^^^^^^^^^^^^^^^^
+.. versionadded:: 2.3.0
+
+`Nested Blueprints <https://flask.palletsprojects.com/en/latest/blueprints/#nesting-blueprints>`__
+require some special considerations.
+
+=====================================
+Exempting routes in nested Blueprints
+=====================================
+
+Expanding the example from the Flask documentation::
+
+    parent = Blueprint('parent', __name__, url_prefix='/parent')
+    child = Blueprint('child', __name__, url_prefix='/child')
+    parent.register_blueprint(child)
+
+    limiter.exempt(parent)
+
+    app.register_blueprint(parent)
+
+Routes under the ``child`` blueprint **do not** automatically get exempted by default
+and have to be marked exempt explicitly. This behavior is to maintain backward compatibility
+and can be opted out of by setting :paramref:`~Limiter.exempt.nested` to ``True``
+when calling :meth:`Limiter.exempt`::
+
+    limiter.exempt(parent, nested=True)
+
+===========================================================
+Explicitly setting limits / exemptions on nested Blueprints
+===========================================================
+
+Using the :paramref:`~Limiter.limit.override_defaults` parameter when
+setting rate limits results in the ancestory of a Blueprint to be taken
+into consideration when selecting the limits to be applied.
+
+For example::
+
+    limiter = Limiter(..., default_limits = ["100/hour"])
+
+    parent = Blueprint('parent', __name__, url_prefix='/parent')
+    child = Blueprint('child', __name__, url_prefix='/child')
+    grandchild = Blueprint('grandchild', __name__, url_prefix='/grandchild')
+
+    health = Blueprint('health', __name__, url_prefix='/health')
+
+    parent.register_blueprint(child)
+    parent.register_blueprint(health)
+    child.register_blueprint(grandchild)
+    child.register_blueprint(health)
+    grandchild.register_blueprint(health)
+
+    app.register_blueprint(parent)
+
+    limiter.limit("2/minute")(parent)
+    limiter.limit("1/second", override_defaults=False)(child)
+    limiter.limit("1000/second")(grandchild)
+
+    limiter.exempt(health)
+
+Effectively this means:
+
+#. Routes under ``parent`` will override the application defaults and will be
+   limited to ``2 per minute``
+
+#. Routes under ``child`` will respect both the parent and the application defaults
+   and effectively be limited to ``At most 1 per second, 2 per minute and 100 per hour``
+
+#. Routes under ``grandchild`` will ignore all other limits and allow ``1000 per second``
+
+#. All calls to ``/health/`` will be exempt from all limits.
+
 
 .. _logging:
 
 Logging
 -------
-Each :class:`~flask_limiter.Limiter` instance has a ``logger`` instance variable that is by
+Each :class:`~Limiter` instance has a ``logger`` instance variable that is by
 default **not** configured with a handler. You can add your own handler to obtain
 log messages emitted by :mod:`flask_limiter`.
 
@@ -185,7 +267,7 @@ Reusing all the handlers of the ``logger`` instance of the :class:`flask.Flask` 
 
 Custom error messages
 ---------------------
-:meth:`~flask_limiter.Limiter.limit` & :meth:`~flask_limiter.Limiter.shared_limit` can be provided with an `error_message`
+:meth:`~Limiter.limit` & :meth:`~Limiter.shared_limit` can be provided with an `error_message`
 argument to over ride the default `n per x` error message that is returned to the calling client.
 The `error_message` argument can either be a simple string or a callable that returns one.
 
@@ -214,8 +296,8 @@ Though you can get pretty far with configuring the standard headers associated
 with rate limiting using configuration parameters available as described under
 :ref:`configuration:rate-limiting headers` - this may not be sufficient for your use case.
 
-For such cases you can access the :attr:`~flask_limiter.Limiter.current_limit`
-property from the :class:`~flask_limiter.Limiter` instance from anywhere within a :doc:`request context <flask:reqcontext>`.
+For such cases you can access the :attr:`~Limiter.current_limit`
+property from the :class:`~Limiter` instance from anywhere within a :doc:`request context <flask:reqcontext>`.
 
 As an example you could leave the built in header population disabled
 and add your own with an :meth:`~flask.Flask.after_request` hook::

--- a/flask_limiter/__init__.py
+++ b/flask_limiter/__init__.py
@@ -1,8 +1,8 @@
 """Flask-Limiter extension for rate limiting."""
 from . import _version
 from .errors import RateLimitExceeded
-from .extension import HEADERS, Limiter, RequestLimit
+from .extension import HEADERS, ExemptionScope, Limiter, RequestLimit
 
-__all__ = ["RateLimitExceeded", "Limiter", "RequestLimit", "HEADERS"]
+__all__ = ["HEADERS", "ExemptionScope", "Limiter", "RateLimitExceeded", "RequestLimit"]
 
 __version__ = _version.get_versions()["version"]

--- a/flask_limiter/errors.py
+++ b/flask_limiter/errors.py
@@ -4,10 +4,7 @@ from werkzeug import exceptions
 
 
 class RateLimitExceeded(exceptions.TooManyRequests):
-    """exception raised when a rate limit is hit.
-
-    The exception results in ``abort(429)`` being called.
-    """
+    """Exception raised when a rate limit is hit."""
 
     def __init__(self, limit):
         self.limit = limit

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -464,20 +464,25 @@ class Limiter(object):
         :param per_method: whether the limit is sub categorized into the
          http method of the request.
         :param methods: if specified, only the methods in this list will
-         be rate limited (default: None).
+         be rate limited (default: ``None``).
         :param error_message: string (or callable that returns one) to override
          the error message used in the response.
         :param exempt_when: function/lambda used to decide if the rate
          limit should skipped.
         :param override_defaults:  whether the decorated limit overrides
-         the default limits. (default: True)
+         the default limits (Default: ``True``).
+
+         .. note:: When used with a :class:`~flask.Blueprint` the meaning
+            of the parameter extends to any parents the blueprint instance is
+            registered under. For more details see :ref:`recipes:nested blueprints`
+
         :param deduct_when: a function that receives the current
          :class:`flask.Response` object and returns True/False to decide if a
          deduction should be done from the rate limit
         :param on_breach: a function that will be called when this limit
          is breached.
         :param cost: The cost of a hit or a function that
-         takes no parameters and returns the cost as an integer (default: 1).
+         takes no parameters and returns the cost as an integer (Default: ``1``).
         """
 
         return self.__limit_decorator(
@@ -519,15 +524,19 @@ class Limiter(object):
          the error message used in the response.
         :param function exempt_when: function/lambda used to decide if the rate
          limit should skipped.
-        :param override_defaults:  whether the decorated limit overrides
-         the default limits. (default: True)
+        :param override_defaults: whether the decorated limit overrides
+         the default limits. (default: ``True``)
+
+         .. note:: When used with a :class:`~flask.Blueprint` the meaning
+            of the parameter extends to any parents the blueprint instance is
+            registered under. For more details see :ref:`recipes:nested blueprints`
         :param deduct_when: a function that receives the current
          :class:`flask.Response`  object and returns True/False to decide if a
          deduction should be done from the rate limit
         :param on_breach: a function that will be called when this limit
          is breached.
         :param cost: The cost of a hit or a function that
-         takes no parameters and returns the cost as an integer (default: 1).
+         takes no parameters and returns the cost as an integer (default: ``1``).
         """
 
         return self.__limit_decorator(
@@ -543,19 +552,19 @@ class Limiter(object):
             cost=cost,
         )
 
-    def exempt(self, obj: Union[Callable, Blueprint], recursive: bool = False):
+    def exempt(self, obj: Union[Callable, Blueprint], nested: bool = False):
         """
         decorator to mark a view or all views in a blueprint as exempt from
         rate limits.
 
         :param obj: view or blueprint to mark as exempt.
-        :param recursive: Only applies to blueprints. This will recursively
-         exempt any blueprints nested under the blueprint referenced by
-         :paramref:`obj`
+        :param nested: Only applies to blueprints. Setting it to ``True``
+         will exempt any blueprints nested under the blueprint referenced by
+         :paramref:`obj` (See :ref:`recipes:nested blueprints`)
         """
 
         if isinstance(obj, Blueprint):
-            if recursive:
+            if nested:
                 self._nested_blueprint_exempt.add(obj.name)
             else:
                 self._blueprint_exempt.add(obj.name)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,6 +5,7 @@ sphinx-copybutton==0.4.0
 sphinxext-opengraph==0.5.1
 Sphinx==4.5.0
 sphinx-autobuild==2021.3.14
+sphinx-issues==3.0.1
 sphinx-panels==0.6.0
 sphinx-paramlinks==0.5.2
 sphinxcontrib-programoutput==0.17

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -65,7 +65,7 @@ def test_nested_blueprint_exemption_explicit(extension_factory):
 def test_nested_blueprint_exemption_legacy(extension_factory):
     """
     To capture legacy behavior, exempting a blueprint
-    will not automatically recursively exempt child blueprints
+    will not automatically exempt nested blueprints
     """
     app, limiter = extension_factory(default_limits=["1/minute"])
     parent_bp = Blueprint("parent", __name__, url_prefix="/parent")
@@ -97,16 +97,12 @@ def test_nested_blueprint_exemption_legacy(extension_factory):
         assert cli.get("/parent/child/").status_code == 429
 
 
-def test_nested_blueprint_exemption_recursive(extension_factory):
-    """
-    To capture legacy behavior, exempting a blueprint
-    will not automatically recursively exempt child blueprints
-    """
+def test_nested_blueprint_exemption_nested(extension_factory):
     app, limiter = extension_factory(default_limits=["1/minute"])
     parent_bp = Blueprint("parent", __name__, url_prefix="/parent")
     child_bp = Blueprint("child", __name__, url_prefix="/child")
 
-    limiter.exempt(parent_bp, recursive=True)
+    limiter.exempt(parent_bp, nested=True)
 
     @app.route("/")
     def root():

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -3,7 +3,7 @@ import datetime
 import hiro
 from flask import Blueprint, Flask, current_app
 
-from flask_limiter import Limiter
+from flask_limiter import ExemptionScope, Limiter
 from flask_limiter.util import get_remote_address
 
 
@@ -102,7 +102,7 @@ def test_nested_blueprint_exemption_nested(extension_factory):
     parent_bp = Blueprint("parent", __name__, url_prefix="/parent")
     child_bp = Blueprint("child", __name__, url_prefix="/child")
 
-    limiter.exempt(parent_bp, nested=True)
+    limiter.exempt(parent_bp, flags=ExemptionScope.DEFAULT | ExemptionScope.DESCENDENTS)
 
     @app.route("/")
     def root():
@@ -126,6 +126,134 @@ def test_nested_blueprint_exemption_nested(extension_factory):
         assert cli.get("/parent/").status_code == 200
         assert cli.get("/parent/child/").status_code == 200
         assert cli.get("/parent/child/").status_code == 200
+
+
+def test_nested_blueprint_exemption_ridiculous(extension_factory):
+    app, limiter = extension_factory(
+        default_limits=["1/minute"], application_limits=["5/day"]
+    )
+    n1 = Blueprint("n1", __name__, url_prefix="/n1")
+    n2 = Blueprint("n2", __name__, url_prefix="/n2")
+    n1_1 = Blueprint("n1_1", __name__, url_prefix="/n1_1")
+    n2_1 = Blueprint("n2_1", __name__, url_prefix="/n2_1")
+    n1_1_1 = Blueprint("n1_1_1", __name__, url_prefix="/n1_1_1")
+    n1_1_2 = Blueprint("n1_1_2", __name__, url_prefix="/n1_1_2")
+    n2_1_1 = Blueprint("n2_1_1", __name__, url_prefix="/n2_1_1")
+
+    @app.route("/")
+    def root():
+        return "42"
+
+    @n1.route("/")
+    def _n1():
+        return "n1"
+
+    @n1_1.route("/")
+    def _n1_1():
+        return "n1_1"
+
+    @n1_1_1.route("/")
+    def _n1_1_1():
+        return "n1_1_1"
+
+    @n1_1_2.route("/")
+    def _n1_1_2():
+        return "n1_1_2"
+
+    @n2.route("/")
+    def _n2():
+        return "n2"
+
+    @n2_1.route("/")
+    def _n2_1():
+        return "n2_1"
+
+    @n2_1_1.route("/")
+    def _n2_1_1():
+        return "n2_1_1"
+
+    # All routes under n1, and it's descendents are exempt for default/application limits
+    limiter.exempt(
+        n1,
+        flags=ExemptionScope.DEFAULT
+        | ExemptionScope.APPLICATION
+        | ExemptionScope.DESCENDENTS,
+    )
+    # n1 descendents are exempt from application & defaults so need their own limits
+    limiter.limit("2/minute")(n1_1)
+    # n1_1_1 wants to not inherit n1_1's limits and is otherwise exempt from
+    # application and defaults due to n1's exemptions.
+    limiter.exempt(n1_1_1, ExemptionScope.ANCESTORS)
+    # n1_1_2 will not get it's parent (n1_1) limit and sets it's own
+    limiter.limit("3/minute")(n1_1_2)
+
+    # n2 overrides the default limits but still gets the application wide limits
+    limiter.limit("2/minute")(n2)
+    # n2_1 wants out of defaults and application limits
+    limiter.exempt(n2_1, flags=ExemptionScope.DEFAULT | ExemptionScope.APPLICATION)
+    # but want its own limits
+    limiter.limit("3/minute")(n2_1)
+    # n2_1_1 want's out of it's parent's limits only but wants to keep application/default limits
+    limiter.exempt(n2_1_1, ExemptionScope.ANCESTORS)
+
+    n1.register_blueprint(n1_1)
+    n1_1.register_blueprint(n1_1_1)
+    n1_1.register_blueprint(n1_1_2)
+    n2.register_blueprint(n2_1)
+    n2_1.register_blueprint(n2_1_1)
+    app.register_blueprint(n1)
+    app.register_blueprint(n2)
+
+    with hiro.Timeline() as timeline:
+        with app.test_client() as cli:
+            assert cli.get("/").status_code == 200
+            assert cli.get("/").status_code == 429  # Default hit
+            # application: exempt, default: exempt, explicit: none
+            assert cli.get("/n1/").status_code == 200
+            assert cli.get("/n1/").status_code == 200
+            # application: exempt from n1, default exempt from n1 & overridden
+            # by explicit: 2/minute
+            assert cli.get("/n1/n1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/").status_code == 429
+            # application: exempt from n1, default: exempt from n1, inherited: exempt,
+            # explicit: none
+            assert cli.get("/n1/n1_1/n1_1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_1/").status_code == 200
+            # application: exempt from n1, default: exempt from n1, inherited: exempt,
+            # explicit: 3/minute
+            assert cli.get("/n1/n1_1/n1_1_2/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_2/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_2/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_2/").status_code == 429
+            # application: active, default: exempt, explicit: 2/minute
+            assert cli.get("/n2/").status_code == 200
+            assert cli.get("/n2/").status_code == 200
+            assert cli.get("/n2/").status_code == 429
+            # application: exempt, default: exempt, explicit: 3/minute therefore overriding n2
+            assert cli.get("/n2/n2_1/").status_code == 200
+            assert cli.get("/n2/n2_1/").status_code == 200
+            assert cli.get("/n2/n2_1/").status_code == 200
+            assert cli.get("/n2/n2_1/").status_code == 429
+            # almost there..
+            # application: active, default: active (1/minute), ancestors: exempt
+            assert cli.get("/n2/n2_1/n2_1_1/").status_code == 200
+            assert cli.get("/n2/n2_1/n2_1_1/").status_code == 429
+            timeline.forward(60)
+            assert cli.get("/n2/n2_1/n2_1_1/").status_code == 200
+            assert cli.get("/n2/n2_1/n2_1_1/").status_code == 429
+            timeline.forward(60)
+            # application limit (5/day) gets this one.
+            assert cli.get("/n2/n2_1/n2_1_1/").status_code == 429
+            # but not those exempt from application limits
+            assert cli.get("/n1/").status_code == 200
+            assert cli.get("/n1/n1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_1/").status_code == 200
+            assert cli.get("/n1/n1_1/n1_1_2/").status_code == 200
+            # but doesn't spare the ones that didn't opt out.
+            assert cli.get("/").status_code == 429
+            assert cli.get("/n2/").status_code == 429
 
 
 def test_nested_blueprint_exemption_child_only(extension_factory):


### PR DESCRIPTION
# Description

Nested blueprints currently do not get accounted for at all in the extension and neither get exempted or respect explicitly registered limits.

This adds support for:
- explicitly marking a blueprint to recursively exempt routes registered under itself or it's nested blueprints.
- explicitly registering a rate limit on a blue print and have it get exercised whether it is nested or not
- Take into account the `override_defaults` flag on the `limit` decorator so that if it is set to `False` when registering a rate limit on a blueprint which gets nested under another blue print which already has rate limits, the parent's limits will get included.

Addresses #326 