### PR TITLE
Update verb to match implementation for key_func

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -231,7 +231,7 @@ as that is delegated to the :pypi:`limits` library.
 
 Rate Limit Domain
 -----------------
-Each :class:`~flask_limiter.Limiter` instance should be initialized with a
+Each :class:`~flask_limiter.Limiter` instance must be initialized with a
 :paramref:`~Limiter.key_func` that returns the bucket in which each request
 is put into when evaluating whether it is within the rate limit or not.
 


### PR DESCRIPTION
I also wonder if the signature annotations of Limiter could change from `key_func: Optional[Callable[[], str]]` to `key_func: Callable[[], str]` but I'm not sure if it can stay with the default assignment. Or if removing the default assignment can be done without reordering.