### PR TITLE
Update exception handling for on_breach callbacks

### DIFF
--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -109,6 +109,11 @@ For example::
             429
           )
 
+.. note::
+   .. versionchanged:: 2.8.0
+      Any errors encountered when calling an :paramref:`~Limiter.on_breach` callback will
+      be re-raised unless :paramref:`~Limiter.swallow_errors` is set to ``True``
+
 For specific rate limit decorated routes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. versionadded:: 2.6.0

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -987,10 +987,10 @@ class Limiter:
                         if isinstance(cb_response, flask.wrappers.Response):
                             on_breach_response = cb_response
                     except Exception as err:  # noqa
-                        self.logger.warning(
-                            "on_breach callback failed with error %s", err
-                        )
-
+                        if self._swallow_errors:
+                            self.logger.exception("on_breach callback failed")
+                        else:
+                            raise err
         if failed_limits:
             raise RateLimitExceeded(
                 sorted(failed_limits, key=lambda x: x[0].limit)[0][0],

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -179,7 +179,6 @@ class Limiter:
         self._swallow_errors = swallow_errors
         self._fail_on_first_breach = fail_on_first_breach
         self._on_breach = on_breach
-
         # No longer optional
         assert key_func
 
@@ -988,7 +987,9 @@ class Limiter:
                             on_breach_response = cb_response
                     except Exception as err:  # noqa
                         if self._swallow_errors:
-                            self.logger.exception("on_breach callback failed")
+                            self.logger.exception(
+                                "on_breach callback failed with error %s", err
+                            )
                         else:
                             raise err
         if failed_limits:

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -97,7 +97,7 @@ class Limiter:
      upon instantiation.
     :param auto_check: whether to automatically check the rate limit in
      the before_request chain of the application. default ``True``
-    :param swallow_errors: whether to swallow errors when hitting a rate
+    :param swallow_errors: whether to swallow any errors when hitting a rate
      limit. An exception will still be logged. default ``False``
     :param fail_on_first_breach: whether to stop processing remaining limits
      after the first breach. default ``True``


### PR DESCRIPTION
# Description
Change the default behaviour to re-raise any exceptions encountered when calling the user provided `on_breach` callbacks. If `swallow_errors` is set to `True` - these exceptions will be absorbed and logged instead.

As a side effect, the logging level for errors encountered when calling the `on_breach` callback is increased to `ERROR` and `logging.exception` is used instead so that the exception stack trace is also provided to the logging handler.

## Related issues
- #367 