### PR TITLE
Fix redis connect_timeout in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -225,7 +225,7 @@ Here are a few common examples:
       limiter = Limiter(
         app, key_func=get_remote_address,
         storage_uri="redis://localhost:6379",
-        storage_options={"connect_timeout": 30},
+        storage_options={"socket_connect_timeout": 30},
         strategy="fixed-window", # or "moving-window"
       )
 
@@ -265,7 +265,7 @@ Here are a few common examples:
         app,
         key_func=get_remote_address,
         storage_uri="redis+cluster://localhost:7000,localhost:7001,localhost:7002",
-        storage_options={"connect_timeout": 30},
+        storage_options={"socket_connect_timeout": 30},
         strategy="fixed-window", # or "moving-window"
       )
 


### PR DESCRIPTION
The doc examples contain an invalid keyword for initializing a Redis memory store. The correct attribute is "socket_connect_timeout": https://github.com/redis/redis-py/blob/master/redis/connection.py#L481