### PR TITLE
Add initial support for decorating plain functions

### DIFF
--- a/flask_limiter/commands.py
+++ b/flask_limiter/commands.py
@@ -117,12 +117,16 @@ def render_limits(
 
     for limit in limits:
         if endpoint:
+            view_func = app.view_functions.get(endpoint, None)
             source = (
                 "blueprint"
                 if blueprint
                 and limit in limiter.limit_manager.blueprint_limits(app, blueprint)
                 else "route"
-                if limit in limiter.limit_manager.route_limits(app, endpoint)
+                if limit
+                in limiter.limit_manager.route_limits(
+                    f"{view_func.__module__}.{view_func.__name__}" if view_func else ""
+                )
                 else "default"
             )
         else:

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -1032,7 +1032,7 @@ class LimitDecorator:
         self.key_func = key_func or self.limiter._key_func
         self.scope = scope if shared else None
         self.per_method = per_method
-        self.methods = methods
+        self.methods = tuple(methods) if methods else None
         self.error_message = error_message
         self.exempt_when = exempt_when
         self.override_defaults = override_defaults

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -233,8 +233,8 @@ class Limiter:
         self.limit_manager = LimitManager(
             application_limits=_application_limits,
             default_limits=_default_limits,
-            static_route_limits={},
-            dynamic_route_limits={},
+            static_decorated_limits={},
+            dynamic_decorated_limits={},
             static_blueprint_limits={},
             dynamic_blueprint_limits={},
             route_exemptions=self._route_exemptions,
@@ -1112,9 +1112,13 @@ class LimitDecorator:
             self.limiter._marked_for_limiting.add(name)
 
             if dynamic_limit:
-                self.limiter.limit_manager.add_runtime_route_limits(name, dynamic_limit)
+                self.limiter.limit_manager.add_decorated_runtime_limit(
+                    name, dynamic_limit
+                )
             else:
-                self.limiter.limit_manager.add_static_route_limits(name, *static_limits)
+                self.limiter.limit_manager.add_decorated_static_limit(
+                    name, *static_limits
+                )
 
             @wraps(obj)
             def __inner(*a: P.args, **k: P.kwargs) -> R:

--- a/flask_limiter/manager.py
+++ b/flask_limiter/manager.py
@@ -15,8 +15,8 @@ class LimitManager:
         self,
         application_limits: List[LimitGroup],
         default_limits: List[LimitGroup],
-        static_route_limits: Dict[str, List[Limit]],
-        dynamic_route_limits: Dict[str, List[LimitGroup]],
+        static_decorated_limits: Dict[str, List[Limit]],
+        dynamic_decorated_limits: Dict[str, List[LimitGroup]],
         static_blueprint_limits: Dict[str, List[Limit]],
         dynamic_blueprint_limits: Dict[str, List[LimitGroup]],
         route_exemptions: Dict[str, ExemptionScope],
@@ -24,8 +24,8 @@ class LimitManager:
     ) -> None:
         self._application_limits = application_limits
         self._default_limits = default_limits
-        self._static_route_limits = static_route_limits
-        self._runtime_route_limits = dynamic_route_limits
+        self._static_decorated_limits = static_decorated_limits
+        self._runtime_decorated_limits = dynamic_decorated_limits
         self._static_blueprint_limits = static_blueprint_limits
         self._runtime_blueprint_limits = dynamic_blueprint_limits
         self._route_exemptions = route_exemptions
@@ -46,14 +46,14 @@ class LimitManager:
     def set_default_limits(self, limits: List[LimitGroup]) -> None:
         self._default_limits = limits
 
-    def add_runtime_route_limits(self, route: str, limit: LimitGroup) -> None:
-        self._runtime_route_limits.setdefault(route, []).append(limit)
+    def add_decorated_runtime_limit(self, route: str, limit: LimitGroup) -> None:
+        self._runtime_decorated_limits.setdefault(route, []).append(limit)
 
     def add_runtime_blueprint_limits(self, blueprint: str, limit: LimitGroup) -> None:
         self._runtime_blueprint_limits.setdefault(blueprint, []).append(limit)
 
-    def add_static_route_limits(self, route: str, *limits: Limit) -> None:
-        self._static_route_limits.setdefault(route, []).extend(limits)
+    def add_decorated_static_limit(self, route: str, *limits: Limit) -> None:
+        self._static_decorated_limits.setdefault(route, []).extend(limits)
 
     def add_static_blueprint_limits(self, blueprint: str, *limits: Limit) -> None:
         self._static_blueprint_limits.setdefault(blueprint, []).extend(limits)
@@ -143,11 +143,11 @@ class LimitManager:
     def route_limits(self, callable_name: str) -> List[Limit]:
         limits = []
         if not self._route_exemptions[callable_name]:
-            for limit in self._static_route_limits.get(callable_name, []):
+            for limit in self._static_decorated_limits.get(callable_name, []):
                 limits.append(limit)
 
-            if callable_name in self._runtime_route_limits:
-                for group in self._runtime_route_limits[callable_name]:
+            if callable_name in self._runtime_decorated_limits:
+                for group in self._runtime_decorated_limits[callable_name]:
                     try:
                         for limit in group:
                             limits.append(limit)

--- a/flask_limiter/wrappers.py
+++ b/flask_limiter/wrappers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 import weakref
-from typing import Callable, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Iterator, List, Optional, Tuple, Union
 
 from flask import request
 from flask.wrappers import Response
@@ -83,7 +83,7 @@ class Limit:
     key_func: Callable[[], str]
     _scope: Optional[Union[str, Callable[[str], str]]]
     per_method: bool = False
-    methods: Optional[Sequence[str]] = None
+    methods: Optional[Tuple[str, ...]] = None
     error_message: Optional[str] = None
     exempt_when: Optional[Callable[[], bool]] = None
     override_defaults: Optional[bool] = False
@@ -93,7 +93,7 @@ class Limit:
 
     def __post_init__(self) -> None:
         if self.methods:
-            self.methods = [k.lower() for k in self.methods]
+            self.methods = tuple([k.lower() for k in self.methods])
 
     @property
     def is_exempt(self) -> bool:
@@ -143,7 +143,7 @@ class LimitGroup:
     limit_provider: Union[Callable[[], str], str]
     key_function: Callable[[], str]
     scope: Optional[Union[str, Callable[[str], str]]] = None
-    methods: Optional[Sequence[str]] = None
+    methods: Optional[Tuple[str, ...]] = None
     error_message: Optional[str] = None
     exempt_when: Optional[Callable[[], bool]] = None
     override_defaults: Optional[bool] = False

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,4 +1,5 @@
 limits>=2.3
 Flask>=2
+ordered-set>4,<5
 rich>=12,<13
 typing_extensions>=4


### PR DESCRIPTION
# Description

The `@limit` & `@shared_limit` decorators had thus far only been usable to decorate functions or methods that were also view functions (i.e decorated with the `@route` decorator or explicitly registered through `add_url_rule` or some other mechanism).

This change allows any function to be decorated with the `@limit` or `@shared_limit` decorator and the wrapper created by the decorator will explicitly exercise the rate limits defined by the decorator (once per request).


## Related Issues & Pull requests
- #377 
- #378 