### PR TITLE
Correct `Limiter` initialization code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Add the rate limiter to your flask app
 
    app = Flask(__name__)
    limiter = Limiter(
-       get_remote_address,
+       key_func=get_remote_address,
        app=app,
        default_limits=["2 per minute", "1 per second"],
        storage_uri="memory://",


### PR DESCRIPTION
Current example code in `README.rst` doesn't work because `Limiter.__init__` expects first argument `app`, but the example was passing `get_remote_address` as first argument to `Limiter.__init__`. This is solved by simply passing it as a keyword argument.