### PR TITLE
Added missing comma

### DIFF
--- a/doc/source/recipes.rst
+++ b/doc/source/recipes.rst
@@ -78,7 +78,7 @@ For example::
 
     def default_error_responder(request_limit: RequestLimit):
         return make_response(
-            render_template("my_ratelimit_template.tmpl", request_limit=request_limit)
+            render_template("my_ratelimit_template.tmpl", request_limit=request_limit),
             429
         )
 


### PR DESCRIPTION
On line 81 there is a missing comma in the `default_error_responder` function right after calling the `render_template` function.