### PR TITLE
Replace use of default dict for exemptions

### DIFF
--- a/flask_limiter/commands.py
+++ b/flask_limiter/commands.py
@@ -1,7 +1,18 @@
 import itertools
 import time
 from functools import partial
-from typing import Any, Callable, Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 import click
@@ -180,7 +191,7 @@ def get_filtered_endpoint(
             filter_endpoint, _ = adapter.match(
                 parsed.path, method=method, query_args=parsed.query
             )
-            return filter_endpoint
+            return cast(str, filter_endpoint)
         except NotFound:
             console.print(
                 f"[error]Error: {path} could not be matched to an endpoint[/error]"

--- a/flask_limiter/extension.py
+++ b/flask_limiter/extension.py
@@ -197,12 +197,8 @@ class Limiter:
         self._in_memory_fallback_enabled = in_memory_fallback_enabled or (
             in_memory_fallback and len(in_memory_fallback) > 0
         )
-        self._route_exemptions: Dict[str, ExemptionScope] = defaultdict(
-            lambda: ExemptionScope.NONE
-        )
-        self._blueprint_exemptions: Dict[str, ExemptionScope] = defaultdict(
-            lambda: ExemptionScope.NONE
-        )
+        self._route_exemptions: Dict[str, ExemptionScope] = {}
+        self._blueprint_exemptions: Dict[str, ExemptionScope] = {}
         self._request_filters: List[Callable[[], bool]] = []
 
         self._headers_enabled = headers_enabled


### PR DESCRIPTION
# Description

Using a defaultdict results in insertions on access which can result to concorrent access errors when iteration on blueprint_exemptions. This also results in unbounded growth of both the route_exemption & blueprint_exemption dictionaries in the limit manager.

## Related issues
#446 