### PR TITLE
Add gcp func to contrib.util

### DIFF
--- a/flask_limiter/contrib/util.py
+++ b/flask_limiter/contrib/util.py
@@ -8,3 +8,16 @@ def get_remote_address_cloudflare() -> str:
 
     """
     return request.headers["CF-Connecting-IP"] or "127.0.0.1"
+
+def get_remote_address_gcp() -> str:
+    """
+    :return: the ip address for the current request from the X-Forwarded-For header
+     (or 127.0.0.1 if none found)
+
+    """
+    x_forwarded_for = request.headers.get('X-Forwarded-For')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0].strip()
+    else:
+        ip = request.remote_addr or "127.0.0.1"
+    return ip


### PR DESCRIPTION
GCP handles each request throw different load balancers and reverse proxies so using remote_addr is unreliable to obtain the client IP. As per [their documentation](https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header), the client IP is carried on in the **X-Forwarded-For** header. However, this is an array where each network node of GCP appends it's IP so the first in the list is the client IP (unless it's a spoofed request).